### PR TITLE
Use `connected-` start and stop scripts scripts

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -77,12 +77,12 @@ done
   fi
 
   scripts/start-core --detach
-  services/mine-support/scripts/start --detach
-  services/mine-support-api-gateway/scripts/start --detach
-  services/mine-support-calculation-service/scripts/start --detach
-  services/mine-support-claim-service/scripts/start --detach
-  services/mine-support-payment-service/scripts/start --detach
-  services/mine-support-user-service/scripts/start --detach
+  services/mine-support/scripts/connected-start --detach
+  services/mine-support-api-gateway/scripts/connected-start --detach
+  services/mine-support-calculation-service/scripts/connected-start --detach
+  services/mine-support-claim-service/scripts/connected-start --detach
+  services/mine-support-payment-service/scripts/connected-start --detach
+  services/mine-support-user-service/scripts/connected-start --detach
 
   if [ ${quick} ]; then
     printf "\n\nWarning: services were not rebuilt so any changes to dependencies will not have been applied."

--- a/scripts/stop
+++ b/scripts/stop
@@ -13,11 +13,11 @@ projectRoot=$(a="/$0"; a=${a%/*}; a=${a:-.}; a=${a#/}/; cd "$a/.." || return; pw
 (
   cd "${projectRoot}"
 
-  services/mine-support/scripts/stop
-  services/mine-support-api-gateway/scripts/stop
-  services/mine-support-calculation-service/scripts/stop
-  services/mine-support-claim-service/scripts/stop
-  services/mine-support-payment-service/scripts/stop
-  services/mine-support-user-service/scripts/stop
+  services/mine-support/scripts/connected-stop
+  services/mine-support-api-gateway/scripts/connected-stop
+  services/mine-support-calculation-service/scripts/connected-stop
+  services/mine-support-claim-service/scripts/connected-stop
+  services/mine-support-payment-service/scripts/connected-stop
+  services/mine-support-user-service/scripts/connected-stop
   scripts/stop-core
 )


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-480

Service scripts are being updated to default to isolated start.
Connecting services together will be achieved via new connected-start
and connected-stop scripts.